### PR TITLE
feat: basic pdf generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ wasm-bindgen-futures = "0.4.50"
 async-std = "1.13.1"
 uuid = { version = "1.17.0", features = ["v4", "js"] }
 gotenberg_pdf = { version = "0.5.2", optional = true }
+base64 = { version = "0.22.1", optional = true }
 
 [features]
 csr = ["leptos/csr"]
@@ -48,6 +49,7 @@ ssr = [
   "dep:sqlx",
   "dep:futures",
   "dep:gotenberg_pdf",
+  "dep:base64",
 ]
 
 # Added by me for file uploading

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures = { version = "0.3", optional = true }
 wasm-bindgen-futures = "0.4.50"
 async-std = "1.13.1"
 uuid = { version = "1.17.0", features = ["v4", "js"] }
+gotenberg_pdf = { version = "0.5.2", optional = true }
 
 [features]
 csr = ["leptos/csr"]
@@ -46,6 +47,7 @@ ssr = [
   #Added by me
   "dep:sqlx",
   "dep:futures",
+  "dep:gotenberg_pdf",
 ]
 
 # Added by me for file uploading

--- a/migrations/0004_pdf_support.sql
+++ b/migrations/0004_pdf_support.sql
@@ -1,0 +1,8 @@
+-- storing the config like this is not the ideal, but I already have a database
+-- and I don't want to deal with creating, serializing... a config file
+CREATE TABLE config (
+ id INTEGER PRIMARY KEY CHECK (id = 1),
+ gotenberg_location TEXT NULL
+);
+
+INSERT INTO config (id, gotenberg_location) VALUES (1, NULL);

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,0 +1,59 @@
+use leptos::prelude::*;
+
+#[cfg(feature = "ssr")]
+use actix_web::web::Data;
+#[cfg(feature = "ssr")]
+use leptos_actix::extract;
+#[cfg(feature = "ssr")]
+use sqlx::{Error, Pool, Row, Sqlite};
+#[cfg(feature = "ssr")]
+use std::sync::Arc;
+
+use crate::models::config::Config;
+
+#[server(GetConfig, "/api/config")]
+pub async fn get_config() -> Result<Config, ServerFnError> {
+    let ext: Data<Pool<Sqlite>> = extract().await?;
+    let pool: Arc<Pool<Sqlite>> = ext.into_inner();
+
+    let row_result = sqlx::query("SELECT * FROM config WHERE id = ?")
+        .bind(1)
+        .fetch_one(&*pool)
+        .await;
+
+    match row_result {
+        Ok(row) => {
+            let config: Config = Config {
+                id: row.get("id"),
+                gotenberg_location: row.get("gotenberg_location"),
+            };
+            Ok(config)
+        }
+        Err(Error::RowNotFound) => Err(ServerFnError::new(String::from("Config not found"))),
+        Err(err) => Err(ServerFnError::new(format!("Server Error: {err}"))),
+    }
+}
+
+#[server(UpdateConfig, "/api/config/update")]
+pub async fn update_config(gotenberg_location: String) -> Result<i32, ServerFnError> {
+    let ext: Data<Pool<Sqlite>> = extract().await?;
+    let pool: Arc<Pool<Sqlite>> = ext.into_inner();
+
+    let command_res = sqlx::query(
+        "UPDATE config
+            SET
+                gotenberg_location = ?
+            WHERE
+                id = ?
+        ",
+    )
+    .bind(gotenberg_location)
+    .bind(1)
+    .execute(&*pool)
+    .await;
+
+    match command_res {
+        Ok(result) => Ok(result.rows_affected().try_into().unwrap()),
+        Err(err) => Err(ServerFnError::new(format!("Server Error: {err}"))),
+    }
+}

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -58,11 +58,79 @@ pub async fn update_config(gotenberg_location: String) -> Result<i32, ServerFnEr
     }
 }
 
+// #[server(ExportPdf, "/api/config/exportpdf")]
+// pub async fn export_pdf(
+//     body_html: String,
+//     recipe_image_path: String,
+// ) -> Result<String, ServerFnError> {
+//     use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+//     let config = get_config()
+//         .await
+//         .map_err(|err| ServerFnError::new(format!("Failed to get config: {err}")))?;
+
+//     if config
+//         .gotenberg_location
+//         .as_ref()
+//         .is_none_or(|loc| loc.is_empty())
+//     {
+//         return Err(ServerFnError::new(
+//             "No Gotenberg location found".to_string(),
+//         ));
+//     }
+
+//     //  let static_dir = std::env::var("LEPTOS_SITE_ROOT")
+//     //     .or_else(|_| std::env::var("STATIC_DIR"))
+//     //     .unwrap_or_else(|_| "target/site".to_string());
+
+//     // let css_path = format!("{}/pkg/cocookies.css", static_dir);
+//     // let css = std::fs::read_to_string(&css_path)
+//     //     .map_err(|err| ServerFnError::new(format!("Failed to read CSS file: {err}")))?;
+
+//     let current_dir = std::env::current_dir()
+//         .map_err(|err| ServerFnError::new(format!("Failed to get current directory: {err}")))?;
+//     let css_path = current_dir.join("target/site/pkg/cocookies.css");
+//     let css = std::fs::read_to_string(&css_path).map_err(|err| {
+//         ServerFnError::new(format!("Failed to read CSS from {css_path:?}: {err}"))
+//     })?;
+
+//     let base64_image = if let Ok(image) = std::fs::read(&recipe_image_path) {
+//         STANDARD.encode(&image)
+//     } else {
+//         return Err(ServerFnError::new(format!(
+//             "Can't encode image with path: {recipe_image_path}"
+//         )));
+//     };
+
+//     let html = format!(
+//         r#"<!DOCTYPE html>
+//             <html lang="en">
+//                 <head>
+//                     <meta charset="UTF-8">
+//                     <style>{css}</style>
+//                 </head>
+//                 <body>
+//                     {body_html}
+//                 </body>
+//             </html>"#
+//     );
+
+//     let client = gotenberg_pdf::Client::new(&config.gotenberg_location.unwrap());
+//     let result = client
+//         .pdf_from_html(&html, gotenberg_pdf::WebOptions::default())
+//         .await;
+
+//     match result {
+//         Ok(bytes) => Ok(STANDARD.encode(&bytes)),
+//         Err(err) => {
+//             eprintln!("{err}");
+//             Err(ServerFnError::new(format!("Gotenberg Error: {err}")))
+//         }
+//     }
+// }
+
 #[server(ExportPdf, "/api/config/exportpdf")]
-pub async fn export_pdf(
-    body_html: String,
-    recipe_image_path: String,
-) -> Result<String, ServerFnError> {
+pub async fn export_pdf(recipe_id: i32) -> Result<String, ServerFnError> {
     use base64::{Engine as _, engine::general_purpose::STANDARD};
 
     let config = get_config()
@@ -79,45 +147,73 @@ pub async fn export_pdf(
         ));
     }
 
-    //  let static_dir = std::env::var("LEPTOS_SITE_ROOT")
-    //     .or_else(|_| std::env::var("STATIC_DIR"))
-    //     .unwrap_or_else(|_| "target/site".to_string());
+    let recipe = crate::api::recipe::get_recipe(recipe_id)
+        .await
+        .unwrap_or_default();
+    let recipe_ingredients = crate::api::recipe_ingredients::get_all_recipe_ingredients(recipe_id)
+        .await
+        .unwrap_or_default();
+    let recipe_steps = crate::api::recipe_steps::get_all_recipe_steps(recipe_id)
+        .await
+        .unwrap_or_default();
+    let recipe_notes = crate::api::recipe_notes::get_all_recipe_notes(recipe_id)
+        .await
+        .unwrap_or_default();
 
-    // let css_path = format!("{}/pkg/cocookies.css", static_dir);
-    // let css = std::fs::read_to_string(&css_path)
-    //     .map_err(|err| ServerFnError::new(format!("Failed to read CSS file: {err}")))?;
+    let recipe_html = format!(
+        r#"<h1>{}</h1>
+            <p>{} ({} servings, {}min)</p>
+        "#,
+        recipe.name,
+        recipe.description.unwrap_or_default(),
+        recipe.servings.unwrap_or_default(),
+        recipe.prep_time_minutes.unwrap_or_default()
+    );
 
-    let current_dir = std::env::current_dir()
-        .map_err(|err| ServerFnError::new(format!("Failed to get current directory: {err}")))?;
-    let css_path = current_dir.join("target/site/pkg/cocookies.css");
-    let css = std::fs::read_to_string(&css_path).map_err(|err| {
-        ServerFnError::new(format!("Failed to read CSS from {css_path:?}: {err}"))
-    })?;
+    let mut ingredients_html = String::from("<h1>Ingredients</h1>");
+    for ingredient in recipe_ingredients {
+        if ingredient.quantity.is_some() || ingredient.unit.is_some() {
+            ingredients_html += &format!(
+                "<p>{} {} - {}</p>",
+                ingredient.quantity.unwrap_or_default(),
+                ingredient.unit.unwrap_or_default(),
+                ingredient.ingredient_name
+            )
+            .to_string();
+        } else {
+            ingredients_html += &format!("<p>{}</p>", ingredient.ingredient_name).to_string();
+        }
+    }
 
-    let base64_image = if let Ok(image) = std::fs::read(&recipe_image_path) {
-        STANDARD.encode(&image)
-    } else {
-        return Err(ServerFnError::new(format!(
-            "Can't encode image with path: {recipe_image_path}"
-        )));
-    };
+    let mut steps_html = String::from("<h1>Steps</h1>");
+    for step in recipe_steps {
+        steps_html += &format!("<p>{}</p>", step.instructions,).to_string();
+    }
 
-    let html = format!(
+    let mut notes_html = String::from("<h1>Notes</h1>");
+    for note in recipe_notes {
+        notes_html += &format!("<p>{}</p>", note.note,).to_string();
+    }
+
+    let result_html = format!(
         r#"<!DOCTYPE html>
             <html lang="en">
                 <head>
                     <meta charset="UTF-8">
-                    <style>{css}</style>
+                    <title>Recipe Export</title>
                 </head>
                 <body>
-                    {body_html}
+                    {recipe_html}
+                    {ingredients_html}
+                    {steps_html}
+                    {notes_html}
                 </body>
             </html>"#
     );
 
     let client = gotenberg_pdf::Client::new(&config.gotenberg_location.unwrap());
     let result = client
-        .pdf_from_html(&html, gotenberg_pdf::WebOptions::default())
+        .pdf_from_html(&result_html, gotenberg_pdf::WebOptions::default())
         .await;
 
     match result {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod recipe;
 pub mod recipe_ingredients;
 pub mod recipe_notes;

--- a/src/components/recipe/edit_recipe.rs
+++ b/src/components/recipe/edit_recipe.rs
@@ -54,10 +54,12 @@ pub fn ViewEditRecipeComponent(recipe: Recipe, main_photo_change: WriteSignal<bo
         String::from("/assets/utils/image-not-found.png")
     };
 
+    let photo_path_for_action = photo_path.clone();
     let export_pdf_action = Action::new(move |body_html: &String| {
         let body = body_html.clone();
+        let photo_path_for_action = photo_path_for_action.clone();
         async move { 
-            let result = export_pdf(body).await;
+            let result = export_pdf(body, photo_path_for_action).await;
             match result {
                 Ok(base64_pdf) => {
                      let download_pdf = move || {

--- a/src/components/recipe/edit_recipe.rs
+++ b/src/components/recipe/edit_recipe.rs
@@ -80,14 +80,25 @@ pub fn ViewEditRecipeComponent(recipe: Recipe, main_photo_change: WriteSignal<bo
                         <div class="w-full">
                             <div class="flex justify-between items-center w-full">
                                 <h1 class="text-4xl font-bold">{move || model.read_only().get().name}</h1>
-                                <button
-                                    class="btn btn-sm btn-ghost"
-                                    on:click=move |_| {
-                                        let _ = edit_dialog_ref.get().unwrap().show_modal();
-                                    }
-                                >
-                                    "Edit"
-                                </button>
+                                <div class="flex gap-1">
+                                    <button
+                                        class="btn btn-sm btn-ghost"
+                                        on:click=move |_| {
+                                            let _ = edit_dialog_ref.get().unwrap().show_modal();
+                                        }
+                                    >
+                                        "Edit"
+                                    </button>
+
+                                    <button
+                                        class="btn btn-sm btn-secondary text-black"
+                                        on:click=move |_| {
+                                            
+                                        }
+                                    >
+                                        "Export PDF"
+                                    </button>
+                                </div>
                             </div>
                             <p>{move || model.read_only().get().description}</p>
                         </div>

--- a/src/components/recipe/edit_recipe.rs
+++ b/src/components/recipe/edit_recipe.rs
@@ -54,12 +54,10 @@ pub fn ViewEditRecipeComponent(recipe: Recipe, main_photo_change: WriteSignal<bo
         String::from("/assets/utils/image-not-found.png")
     };
 
-    let photo_path_for_action = photo_path.clone();
-    let export_pdf_action = Action::new(move |body_html: &String| {
-        let body = body_html.clone();
-        let photo_path_for_action = photo_path_for_action.clone();
+    let export_pdf_action = Action::new(move |recipe_id: &i32| {
+        let recipe_id = *recipe_id;
         async move { 
-            let result = export_pdf(body, photo_path_for_action).await;
+            let result = export_pdf(recipe_id).await;
             match result {
                 Ok(base64_pdf) => {
                      let download_pdf = move || {
@@ -127,10 +125,7 @@ pub fn ViewEditRecipeComponent(recipe: Recipe, main_photo_change: WriteSignal<bo
                                     <button
                                         class="btn btn-sm btn-secondary text-black"
                                         on:click=move |_| {
-                                            if let Some(body) = leptos::prelude::document().body() {
-                                                let body_html = body.inner_html();
-                                                export_pdf_action.dispatch(body_html);
-                                            };
+                                            export_pdf_action.dispatch(model.get_untracked().recipe_id.unwrap_or_default());
                                         }
                                     >
                                         "Export PDF"

--- a/src/components/settings/export_pdf_options.rs
+++ b/src/components/settings/export_pdf_options.rs
@@ -1,0 +1,93 @@
+use leptos::prelude::*;
+
+use crate::{
+    api::config::{get_config, UpdateConfig},
+    components::{page_loading::PageLoadingComponent, toast::{ToastMessage, ToastType}},
+};
+
+#[component]
+pub fn ExportPDFOptionsComponent() -> impl IntoView {
+    let set_toast: WriteSignal<ToastMessage> = expect_context();
+    let config = OnceResource::new(get_config());
+    let update_config = ServerAction::<UpdateConfig>::new();
+
+    // 'value' holds the latest *returned* value from the server
+    let value = update_config.value();
+    Effect::new(move |_| {
+        if let Some(val) = value.get() {
+            match val {
+                Ok(_) => {
+                    set_toast.set(ToastMessage {
+                        message: String::from("Changed Saved"),
+                        toast_type: ToastType::Success,
+                        visible: true,
+                    });
+                }
+                Err(err) => {
+                    set_toast.set(ToastMessage {
+                        message: format!("Error Saving {err}"),
+                        toast_type: ToastType::Error,
+                        visible: true,
+                    });
+                }
+            }
+        }
+    });
+    
+    view! {
+        <Suspense fallback=move || view! { <PageLoadingComponent/> }>
+            <ErrorBoundary fallback=|error| view! {
+                <p class="text-xl text-center text-red-500">"An error occurred: " {format!("{error:?}")}</p>
+            }>
+            { move || {
+                config.get().map(move |c| {
+                    c.map(move |config| {
+                        let model = RwSignal::new(config);
+
+                        view! {
+                            <ActionForm action=update_config>
+                                <div class="card bg-base-100 shadow-xl w-96">
+                                    <div class="card-body w-full">
+                                        <a class="link" target="_blank" href="https://github.com/gotenberg/gotenberg" class="text-xl">"Set Gotenberg Server Location"</a>
+                                        <p class="text-xs">"*Ej: http://localhost:3000"</p>
+                                        <br/>
+                                        <fieldset>
+                                            <input type="text"
+                                                class="input w-full"
+                                                name="gotenberg_location"
+                                                id="gotenberg_location"
+                                                autocomplete="off"
+                                                prop:value=move || model.get().gotenberg_location.unwrap_or_default()
+                                                on:input=move |ev| {
+                                                    if !event_target_value(&ev).is_empty() {
+                                                        model.update(|curr| {
+                                                            curr.gotenberg_location = Some(event_target_value(&ev));
+                                                        });
+                                                    } else {
+                                                        model.update(|curr| {
+                                                            curr.gotenberg_location = None;
+                                                        });
+                                                    }
+                                                }
+                                            />
+                                        </fieldset>
+                                        <br/>
+                                        <div class="flex flex-row-reverse gap-1">
+                                            <button class="btn btn-success"
+                                                on:click=move |_| {
+                                                
+                                            }>
+                                                "Save"
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </ActionForm>
+                        }
+                    })
+                })
+            }}
+            </ErrorBoundary>
+        </Suspense>
+    }.into_any()
+}

--- a/src/components/settings/mod.rs
+++ b/src/components/settings/mod.rs
@@ -1,2 +1,3 @@
 pub mod export_data;
+pub mod export_pdf_options;
 pub mod import_data;

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+pub struct Config {
+    pub id: Option<i32>,
+    pub gotenberg_location: Option<String>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod recipe;
 pub mod recipe_ingredient;
 pub mod recipe_note;

--- a/src/pages/settings.rs
+++ b/src/pages/settings.rs
@@ -1,7 +1,8 @@
 use leptos::prelude::*;
 
 use crate::components::settings::{
-    export_data::ExportDataCardComponent, import_data::ImportDataCardComponent,
+    export_data::ExportDataCardComponent, export_pdf_options::ExportPDFOptionsComponent,
+    import_data::ImportDataCardComponent,
 };
 
 #[component]
@@ -15,6 +16,12 @@ pub fn SettingsPage() -> impl IntoView {
                 <div class="flex flex-wrap gap-2">
                     <ExportDataCardComponent/>
                     <ImportDataCardComponent/>
+                </div>
+            </div>
+            <div>
+                <h2 class="text-2xl font-bold">"Export PDF"</h2>
+                <div class="flex flex-wrap gap-2">
+                    <ExportPDFOptionsComponent/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR introduces very basic PDF generation capabilities, making use of the [gotenberg_pdf](https://github.com/phayes/gotenberg_pdf) crate, which allows us to easily use [gotenberg](https://github.com/gotenberg/gotenberg) to generate PDF's. This means that in order for the PDF generation to work, you will need to run a gotenberg instance and provide its URL in the application settings page. It would be nice to not require an extra container for PDF generation, but if down the line we want to generate more complex and styled PDF's, this is the easiest and the best option I could find, since creating PDF's by providing coordinates... is no fun task.